### PR TITLE
#45 During the work on enabling non-200 code, lon…

### DIFF
--- a/data/package.json
+++ b/data/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ty-ras/data",
-  "version": "0.12.3",
+  "version": "0.13.0",
   "author": {
     "name": "Stanislav Muhametsin",
     "email": "346799+stazz@users.noreply.github.com",

--- a/data/src/__test__/methods.spec.ts
+++ b/data/src/__test__/methods.spec.ts
@@ -1,0 +1,24 @@
+import test from "ava";
+import * as spec from "../methods";
+
+test("Validate isMethodWithoutRequestBody works", (t) => {
+  t.plan(8);
+  for (const [method, result] of Object.entries(methodRequestBodySpec)) {
+    t.deepEqual(
+      spec.isMethodWithoutRequestBody(method as spec.HttpMethod),
+      result,
+      `The return value of isMethodWithoutRequestBody for ${method} must be expected`,
+    );
+  }
+});
+
+const methodRequestBodySpec: Record<spec.HttpMethod, boolean> = {
+  OPTIONS: true,
+  GET: true,
+  POST: false,
+  PUT: false,
+  DELETE: false,
+  HEAD: true,
+  PATCH: false,
+  TRACE: true,
+};

--- a/data/src/index.ts
+++ b/data/src/index.ts
@@ -10,6 +10,7 @@ export type {
   DataValidatorResultSuccess,
   OneOrMany,
 } from "./common";
+export * from "./methods";
 export * from "./utils";
 export * from "./combine";
 export type {

--- a/data/src/methods.ts
+++ b/data/src/methods.ts
@@ -1,0 +1,32 @@
+export type HttpMethod =
+  | typeof METHOD_GET
+  | typeof METHOD_HEAD
+  | typeof METHOD_POST
+  | typeof METHOD_PUT
+  | typeof METHOD_PATCH
+  | typeof METHOD_DELETE
+  | typeof METHOD_OPTIONS
+  | typeof METHOD_TRACE;
+
+export type HttpMethodWithoutBody = keyof typeof HttpMethodsWithoutBody;
+export type HttpMethodWithBody = Exclude<HttpMethod, HttpMethodWithoutBody>;
+
+export const isMethodWithoutRequestBody = (
+  method: HttpMethod,
+): method is HttpMethodWithoutBody => method in HttpMethodsWithoutBody;
+
+export const METHOD_GET = "GET";
+export const METHOD_HEAD = "HEAD";
+export const METHOD_POST = "POST";
+export const METHOD_PUT = "PUT";
+export const METHOD_PATCH = "PATCH";
+export const METHOD_DELETE = "DELETE";
+export const METHOD_OPTIONS = "OPTIONS";
+export const METHOD_TRACE = "TRACE";
+
+const HttpMethodsWithoutBody = {
+  [METHOD_TRACE]: true,
+  [METHOD_GET]: true,
+  [METHOD_OPTIONS]: true,
+  [METHOD_HEAD]: true,
+} as const;

--- a/protocol/package.json
+++ b/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ty-ras/protocol",
-  "version": "0.12.1",
+  "version": "0.13.0",
   "author": {
     "name": "Stanislav Muhametsin",
     "email": "346799+stazz@users.noreply.github.com",


### PR DESCRIPTION
…g overdue refactor was discovered: HTTP methods should be put in package shared by BE and FE frameworks.