### PR TITLE
#49 The HTTP method needs to be specified only on…

### DIFF
--- a/data-frontend/package.json
+++ b/data-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ty-ras/data-frontend",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "author": {
     "name": "Stanislav Muhametsin",
     "email": "346799+stazz@users.noreply.github.com",

--- a/data-frontend/src/__test__/api-call-factory-factory.spec.ts
+++ b/data-frontend/src/__test__/api-call-factory-factory.spec.ts
@@ -15,9 +15,9 @@ test("API Call Factory Factory works", async (t) => {
     { method: "GET", url: "dummy" },
     { body: { protocol: "APIEndpoint" } },
     ({ apiCallFactory, expectedArg: { url } }) =>
-      apiCallFactory.makeAPICall<APIEndpoint>("GET", {
+      apiCallFactory.makeAPICall<APIEndpoint>({
         url,
-        method: validatorForValue("GET"),
+        method: "GET",
         response: validatorForValue({ protocol: "APIEndpoint" }),
       })(),
   );
@@ -27,9 +27,9 @@ test("API Call Factory Factory works", async (t) => {
     { method: "GET", url: "dummy", headers: { Authorization: "token" } },
     { body: { protocol: "APIEndpointWithHeaderFunctionality" } },
     ({ apiCallFactory, expectedArg: { url } }) =>
-      apiCallFactory.makeAPICall<APIEndpointWithHeaderFunctionality>("GET", {
+      apiCallFactory.makeAPICall<APIEndpointWithHeaderFunctionality>({
         url,
-        method: validatorForValue("GET"),
+        method: "GET",
         response: validatorForValue({
           protocol: "APIEndpointWithHeaderFunctionality",
         }),
@@ -48,9 +48,9 @@ test("API Call Factory Factory works", async (t) => {
     },
     { body: { protocol: "APIEndpointWithHeaderData" } },
     ({ apiCallFactory, expectedArg: { url } }) =>
-      apiCallFactory.makeAPICall<APIEndpointWithHeaderData>("GET", {
+      apiCallFactory.makeAPICall<APIEndpointWithHeaderData>({
         url,
-        method: validatorForValue("GET"),
+        method: "GET",
         response: validatorForValue({
           protocol: "APIEndpointWithHeaderData",
         }),
@@ -72,9 +72,9 @@ test("API Call Factory Factory works", async (t) => {
       headers: { "X-Custom-Response-Header": "ResponseHeaderValue" },
     },
     ({ apiCallFactory, expectedArg: { url } }) =>
-      apiCallFactory.makeAPICall<APIEndpointWithResponseHeaders>("GET", {
+      apiCallFactory.makeAPICall<APIEndpointWithResponseHeaders>({
         url,
-        method: validatorForValue("GET"),
+        method: "GET",
         response: validatorForValue({
           protocol: "APIEndpointWithResponseHeaders",
         }),
@@ -95,9 +95,9 @@ test("API Call Factory Factory works", async (t) => {
       },
     },
     ({ apiCallFactory, expectedArg: { url } }) =>
-      apiCallFactory.makeAPICall<APIEndpointWithResponseHeaders>("GET", {
+      apiCallFactory.makeAPICall<APIEndpointWithResponseHeaders>({
         url,
-        method: validatorForValue("GET"),
+        method: "GET",
         response: validatorForValue({
           protocol: "APIEndpointWithResponseHeaders",
         }),
@@ -116,7 +116,7 @@ test("API Call Factory Factory works", async (t) => {
 });
 
 test("API Call Factory Factory detects erroneous parameters", async (t) => {
-  t.plan(3);
+  t.plan(2);
   const httpCall: spec.CallHTTPEndpoint = () => {
     throw new Error("This should not be called");
   };
@@ -125,24 +125,10 @@ test("API Call Factory Factory detects erroneous parameters", async (t) => {
     () =>
       spec
         .createAPICallFactoryGeneric(httpCall)
-        .withHeaders({})
-        .makeAPICall<APIEndpoint>("POST" as any, {
-          url,
-          method: validatorForValue("GET"),
-          response: validatorForValue({ protocol: "APIEndpoint" }),
-        }),
-    {
-      message: 'Invalid method: "POST".',
-    },
-  );
-  t.throws(
-    () =>
-      spec
-        .createAPICallFactoryGeneric(httpCall)
         .withHeaders({ auth: () => "dummyHeaderValue" })
-        .makeAPICall<APIEndpointWithHeaderFunctionality>("GET", {
+        .makeAPICall<APIEndpointWithHeaderFunctionality>({
           url,
-          method: validatorForValue("GET"),
+          method: "GET",
           response: validatorForValue({
             protocol: "APIEndpointWithHeaderFunctionality",
           }),
@@ -159,9 +145,9 @@ test("API Call Factory Factory detects erroneous parameters", async (t) => {
     await spec
       .createAPICallFactoryGeneric(httpCall)
       .withHeaders({})
-      .makeAPICall<APIEndpointWithHeaderData>("GET", {
+      .makeAPICall<APIEndpointWithHeaderData>({
         url,
-        method: validatorForValue("GET"),
+        method: "GET",
         response: validatorForValue({ protocol: "APIEndpointWithHeaderData" }),
         headers: validatorForValue({
           "X-Custom-Header": "HeaderValue",

--- a/data-frontend/src/__test__/errors.spec.ts
+++ b/data-frontend/src/__test__/errors.spec.ts
@@ -1,0 +1,45 @@
+import test from "ava";
+import * as spec from "../errors";
+
+test("Validate that error object passes as-is", (c) => {
+  c.plan(1);
+  const error = new Error("Error");
+  c.is(spec.toErrorFE(error), error);
+});
+
+test("Validate that output error returns expected error message", (c) => {
+  c.plan(1);
+  c.deepEqual(
+    spec.toErrorFE({ error: "error", errorInfo, getHumanReadableMessage })
+      .message,
+    `Error with API call output: ${MESSAGE}`,
+  );
+});
+
+test("Validate that input error returns expected error message", (c) => {
+  c.plan(2);
+  c.deepEqual(
+    spec.toErrorFE({
+      error: "error-input",
+      errorInfo: { body: { error: "missing-validator" } },
+    }).message,
+    'Error with API call input: No validator for "body".',
+  );
+
+  c.deepEqual(
+    spec.toErrorFE({
+      error: "error-input",
+      errorInfo: {
+        url: {
+          error: "validator-error",
+          errorInfo: { error: "error", errorInfo, getHumanReadableMessage },
+        },
+      },
+    }).message,
+    `Error with API call input: Validator for "url" returned: ${MESSAGE}`,
+  );
+});
+
+const getHumanReadableMessage = () => MESSAGE;
+const MESSAGE = "The message";
+const errorInfo = undefined;

--- a/data-frontend/src/api-call-factory-factory.ts
+++ b/data-frontend/src/api-call-factory-factory.ts
@@ -18,40 +18,37 @@ export const createAPICallFactoryGeneric = <
     withHeaders: (headers) => ({
       makeAPICall: <
         TProtocolSpec extends protocol.ProtocolSpecCore<string, unknown>,
-      >(
-        methodValue: TProtocolSpec["method"],
-        {
-          method,
-          response,
-          url,
-          ...rest
-        }:
-          | (apiCallFactory.MakeAPICallArgs<
-              TProtocolSpec["method"],
-              TProtocolSpec["responseBody"]
-            > &
-              (
-                | apiCallFactory.MakeAPICallArgsURL
-                | apiCallFactory.MakeAPICallArgsURLData<unknown>
-              )) &
-              // eslint-disable-next-line @typescript-eslint/ban-types
-              (| {}
-                | apiCallFactory.MakeAPICallArgsHeadersData<
-                    Record<string, unknown>
-                  >
-                | apiCallFactory.MakeAPICallArgsHeadersFunctionality<
-                    Record<string, string>
-                  >
-                | apiCallFactory.MakeAPICallArgsResponseHeaders<
-                    Record<string, unknown>
-                  >
-                | apiCallFactory.MakeAPICallArgsQuery<
-                    THKTEncoded,
-                    Record<string, unknown>
-                  >
-                | apiCallFactory.MakeAPICallArgsBody<THKTEncoded, unknown>
-              ),
-      ): apiCall.APICall<
+      >({
+        method,
+        response,
+        url,
+        ...rest
+      }:
+        | (apiCallFactory.MakeAPICallArgs<
+            TProtocolSpec["method"],
+            TProtocolSpec["responseBody"]
+          > &
+            (
+              | apiCallFactory.MakeAPICallArgsURL
+              | apiCallFactory.MakeAPICallArgsURLData<unknown>
+            )) &
+            // eslint-disable-next-line @typescript-eslint/ban-types
+            (| {}
+              | apiCallFactory.MakeAPICallArgsHeadersData<
+                  Record<string, unknown>
+                >
+              | apiCallFactory.MakeAPICallArgsHeadersFunctionality<
+                  Record<string, string>
+                >
+              | apiCallFactory.MakeAPICallArgsResponseHeaders<
+                  Record<string, unknown>
+                >
+              | apiCallFactory.MakeAPICallArgsQuery<
+                  THKTEncoded,
+                  Record<string, unknown>
+                >
+              | apiCallFactory.MakeAPICallArgsBody<THKTEncoded, unknown>
+            )): apiCall.APICall<
         Partial<
           Record<"method" | "url" | "query" | "body" | "headers", unknown>
         > | void,
@@ -64,12 +61,6 @@ export const createAPICallFactoryGeneric = <
             }
           : TProtocolSpec["responseBody"]
       > => {
-        const validatedMethod = method(methodValue);
-        if (validatedMethod.error !== "none") {
-          throw new Error(
-            `Invalid method: ${JSON.stringify(validatedMethod.errorInfo)}.`,
-          );
-        }
         if ("headersFunctionality" in rest) {
           const missingHeaders = Object.values(
             rest.headersFunctionality,
@@ -128,7 +119,7 @@ export const createAPICallFactoryGeneric = <
           });
           if (validatedArgs.error === "none") {
             const httpArgs: HTTPInvocationArguments = {
-              method: validatedMethod.data,
+              method,
               ...validatedArgs.data,
             };
             if ("headers" in rest) {

--- a/data-frontend/src/api-call-factory.d.ts
+++ b/data-frontend/src/api-call-factory.d.ts
@@ -8,7 +8,6 @@ export interface APICallFactory<
   THeaders extends string,
 > {
   makeAPICall<TProtocolSpec extends protocol.ProtocolSpecCore<string, unknown>>(
-    method: TProtocolSpec["method"],
     args: MakeAPICallArgs<
       TProtocolSpec["method"],
       TProtocolSpec["responseBody"]
@@ -39,7 +38,7 @@ export interface APICallFactory<
 }
 
 export interface MakeAPICallArgs<TMethod, TResponse> {
-  method: data.DataValidator<unknown, TMethod>;
+  method: TMethod;
   response: data.DataValidator<unknown, protocol.RuntimeOf<TResponse>>;
 }
 

--- a/data-frontend/src/errors.ts
+++ b/data-frontend/src/errors.ts
@@ -1,0 +1,18 @@
+import type * as apiCall from "./api-call";
+
+export const toErrorFE = (error: Error | apiCall.APICallResultError): Error =>
+  error instanceof Error
+    ? error
+    : new Error(
+        `Error with API call ${error.error === "error" ? "output" : "input"}: ${
+          error.error === "error"
+            ? error.getHumanReadableMessage()
+            : Object.entries(error.errorInfo)
+                .map(([kind, error]) =>
+                  error.error === "missing-validator"
+                    ? `No validator for "${kind}".`
+                    : `Validator for "${kind}" returned: ${error.errorInfo.getHumanReadableMessage()}`,
+                )
+                .join("\n")
+        }`,
+      );

--- a/data-frontend/src/index.ts
+++ b/data-frontend/src/index.ts
@@ -25,3 +25,4 @@ export type {
   MakeAPICallArgsURLData,
 } from "./api-call-factory";
 export * from "./api-call-factory-factory";
+export * from "./errors";


### PR DESCRIPTION
…ce now, when creating API endpoint callback.